### PR TITLE
Fix excessive cpu usage polling the device

### DIFF
--- a/examples/automatic.py
+++ b/examples/automatic.py
@@ -55,7 +55,7 @@ parser.add_argument('--verbose', action='store_true', default=False, help='Outpu
 
 args = parser.parse_args()
 
-fanshim = FanShim()
+fanshim = FanShim(poll_time=args.delay/10)
 fanshim.set_hold_time(1.0)
 fanshim.set_fan(False)
 armed = True

--- a/library/fanshim/__init__.py
+++ b/library/fanshim/__init__.py
@@ -8,7 +8,7 @@ __version__ = '0.0.2'
 
 
 class FanShim():
-    def __init__(self, pin_fancontrol=18, pin_button=17):
+    def __init__(self, pin_fancontrol=18, pin_button=17, poll_time=0.001):
         """FAN Shim.
 
         :param pin_fancontrol: BCM pin for fan on/off
@@ -21,6 +21,7 @@ class FanShim():
         self._button_release_handler = None
         self._button_hold_handler = None
         self._button_hold_time = 2.0
+        self._poll_time = poll_time
         self._t_poll = None
 
         atexit.register(self._cleanup)
@@ -145,4 +146,4 @@ class FanShim():
 
             last = current
 
-            time.sleep(0.001)
+            time.sleep(self._poll_time)


### PR DESCRIPTION
Polling the device every 0.001 seconds for a delay argument to automatic.py of say 2 is a little excessive! (used ~3% of a core just doing that), as such, reduced this to a computation on the delay argument passed to automatic.py so that we accept a delay/10 maximum gap between the last poll and actioning. Drops cpu usage to negligible levels.