### PR TITLE
Added basic fan status logging

### DIFF
--- a/examples/automatic.py
+++ b/examples/automatic.py
@@ -46,6 +46,11 @@ def update_led_temperature(temp):
     led_busy.release()
 
 
+def update_status_file(status):
+    with open("/var/log/fanshim_status", "w") as f:
+        f.write(str(int(status)))
+
+
 def get_cpu_temp():
     t = psutil.sensors_temperatures()
     for x in ['cpu-thermal', 'cpu_thermal']:
@@ -148,6 +153,8 @@ try:
 
         if set_fan(enable):
             last_change = t
+
+        update_status_file(enable)
 
         if not args.noled:
             update_led_temperature(t)


### PR DESCRIPTION
Added basic fan status logging for use with external metrics collectors.

Example for Telegraf:

```
[[inputs.file]]
  files = ["/var/log/fanshim_status"]
  name_override = "fanshim_status"
  data_format = "value"
  data_type = "integer"
```