### PR TITLE
Support disabling LED/button for #70

### DIFF
--- a/examples/automatic.py
+++ b/examples/automatic.py
@@ -89,7 +89,7 @@ def set_automatic(status):
     last_change = 0
 
 
-fanshim = FanShim()
+fanshim = FanShim(disable_button=args.nobutton, disable_led=args.noled)
 fanshim.set_hold_time(1.0)
 fanshim.set_fan(False)
 armed = True

--- a/library/fanshim/__init__.py
+++ b/library/fanshim/__init__.py
@@ -8,7 +8,7 @@ __version__ = '0.0.4'
 
 
 class FanShim():
-    def __init__(self, pin_fancontrol=18, pin_button=17, button_poll_delay=0.05):
+    def __init__(self, pin_fancontrol=18, pin_button=17, button_poll_delay=0.05, disable_button=False, disable_led=False):
         """FAN Shim.
 
         :param pin_fancontrol: BCM pin for fan on/off
@@ -24,17 +24,26 @@ class FanShim():
         self._button_hold_time = 2.0
         self._t_poll = None
 
+        self._disable_button = disable_button
+        self._disable_led = disable_led
+
         GPIO.setwarnings(False)
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(self._pin_fancontrol, GPIO.OUT)
-        GPIO.setup(self._pin_button, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
-        self._led = apa102.APA102(1, 15, 14, None, brightness=0.05)
+        if not self._disable_button:
+            GPIO.setup(self._pin_button, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+        if not self._disable_led:
+            self._led = apa102.APA102(1, 15, 14, None, brightness=0.05)
 
         atexit.register(self._cleanup)
 
     def start_polling(self):
         """Start button polling."""
+        if self._disable_button:
+            return
+
         if self._t_poll is None:
             self._t_poll = Thread(target=self._run)
             self._t_poll.daemon = True
@@ -42,6 +51,9 @@ class FanShim():
 
     def stop_polling(self):
         """Stop button polling."""
+        if self._disable_button:
+            return
+
         if self._t_poll is not None:
             self._running = False
             self._t_poll.join()
@@ -112,6 +124,9 @@ class FanShim():
         :param b: Blue (0-255)
 
         """
+        if self._disable_led:
+            return
+
         self._led.set_pixel(0, r, g, b)
         if brightness is not None:
             self._led.set_brightness(0, brightness)

--- a/library/tests/conftest.py
+++ b/library/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Test configuration.
+These allow the mocking of various Python modules
+that might otherwise have runtime side-effects.
+"""
+import sys
+import mock
+import pytest
+
+
+@pytest.fixture(scope='function', autouse=False)
+def GPIO():
+    """Mock RPi.GPIO module."""
+    GPIO = mock.MagicMock()
+    # Fudge for Python < 37 (possibly earlier)
+    sys.modules['RPi'] = mock.Mock()
+    sys.modules['RPi'].GPIO = GPIO
+    sys.modules['RPi.GPIO'] = GPIO
+    yield GPIO
+    del sys.modules['RPi']
+    del sys.modules['RPi.GPIO']
+
+
+@pytest.fixture(scope='function', autouse=False)
+def plasma():
+    """Mock plasma module."""
+    plasma = mock.MagicMock()
+    sys.modules['plasma'] = plasma
+    yield plasma
+    del sys.modules['plasma']
+
+
+@pytest.fixture(scope='function', autouse=False)
+def spidev():
+    """Mock spidev module."""
+    spidev = mock.MagicMock()
+    sys.modules['spidev'] = spidev
+    yield spidev
+    del sys.modules['spidev']
+
+
+@pytest.fixture(scope='function', autouse=False)
+def atexit():
+    """Mock atexit module."""
+    atexit = mock.MagicMock()
+    sys.modules['atexit'] = atexit
+    yield atexit
+    del sys.modules['atexit']
+

--- a/library/tests/conftest.py
+++ b/library/tests/conftest.py
@@ -8,6 +8,13 @@ import pytest
 
 
 @pytest.fixture(scope='function', autouse=False)
+def FanShim():
+    import fanshim
+    yield fanshim.FanShim
+    del sys.modules['fanshim']
+
+
+@pytest.fixture(scope='function', autouse=False)
 def GPIO():
     """Mock RPi.GPIO module."""
     GPIO = mock.MagicMock()
@@ -21,12 +28,12 @@ def GPIO():
 
 
 @pytest.fixture(scope='function', autouse=False)
-def plasma():
-    """Mock plasma module."""
-    plasma = mock.MagicMock()
-    sys.modules['plasma'] = plasma
-    yield plasma
-    del sys.modules['plasma']
+def apa102():
+    """Mock APA102 module."""
+    apa102 = mock.MagicMock()
+    sys.modules['apa102'] = apa102
+    yield apa102
+    del sys.modules['apa102']
 
 
 @pytest.fixture(scope='function', autouse=False)

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -2,11 +2,74 @@ import mock
 import sys
 
 
-def test_setup():
-    sys.modules['RPi'] = mock.Mock()
-    sys.modules['RPi.GPIO'] = mock.Mock()
-    sys.modules['plasma'] = mock.Mock()
+def force_reimport(module):
+    """Force the module under test to be re-imported.
+
+    Because pytest runs all tests within the same scope (this makes me cry)
+    we have to do some manual housekeeping to avoid tests polluting each other.
+
+    In this case, the first `from fanshim import FanShim` would import both plasma
+    and RPi.GPIO from the first test run fixtures. Since we want *clean* fixtures
+    for each test this is not only no good but the results are outright weird-
+
+    IE: functions we expect to be called will have no calls because FanShim
+    receives an entirely different mock object to the one we're validating against.
+
+    Since conftest.py already does some sys.modules mangling I see no reason not to
+    do the same thing here.
+    """
+    try:
+        del sys.modules[module]
+    except KeyError:
+        pass
+
+
+def test_setup(GPIO, plasma):
+    force_reimport('fanshim')
 
     from fanshim import FanShim
     fanshim = FanShim()
-    del fanshim
+
+    GPIO.setwarnings.assert_called_once_with(False)
+    GPIO.setmode.assert_called_once_with(GPIO.BCM)
+    GPIO.setup.assert_has_calls([
+        mock.call(fanshim._pin_fancontrol, GPIO.OUT),
+        mock.call(fanshim._pin_button, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+    ])
+
+    plasma.legacy.set_clear_on_exit.assert_called_once_with(True)
+    plasma.legacy.set_light_count.assert_called_once_with(1)
+    plasma.legacy.set_light.assert_called_once_with(0, 0, 0, 0)
+
+
+def test_button_disable(GPIO, plasma):
+    force_reimport('fanshim')
+
+    from fanshim import FanShim
+    fanshim = FanShim(disable_button=True)
+
+    GPIO.setwarnings.assert_called_once_with(False)
+    GPIO.setmode.assert_called_once_with(GPIO.BCM)
+    GPIO.setup.assert_called_once_with(fanshim._pin_fancontrol, GPIO.OUT)
+
+
+def test_led_disable(GPIO, plasma):
+    force_reimport('fanshim')
+
+    from fanshim import FanShim
+    fanshim = FanShim(disable_led=True)
+
+    GPIO.setwarnings.assert_called_once_with(False)
+    GPIO.setmode.assert_called_once_with(GPIO.BCM)
+    GPIO.setup.assert_has_calls([
+        mock.call(fanshim._pin_fancontrol, GPIO.OUT),
+        mock.call(fanshim._pin_button, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+    ])
+
+    plasma.legacy.set_clear_on_exit.assert_not_called()
+    plasma.legacy.set_light_count.assert_not_called()
+    plasma.legacy.set_light.assert_not_called()
+
+    fanshim.set_light(0, 0, 0)
+    plasma.legacy.set_light.assert_not_called()
+    plasma.legacy.show.assert_not_called()

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -2,32 +2,7 @@ import mock
 import sys
 
 
-def force_reimport(module):
-    """Force the module under test to be re-imported.
-
-    Because pytest runs all tests within the same scope (this makes me cry)
-    we have to do some manual housekeeping to avoid tests polluting each other.
-
-    In this case, the first `from fanshim import FanShim` would import both plasma
-    and RPi.GPIO from the first test run fixtures. Since we want *clean* fixtures
-    for each test this is not only no good but the results are outright weird-
-
-    IE: functions we expect to be called will have no calls because FanShim
-    receives an entirely different mock object to the one we're validating against.
-
-    Since conftest.py already does some sys.modules mangling I see no reason not to
-    do the same thing here.
-    """
-    try:
-        del sys.modules[module]
-    except KeyError:
-        pass
-
-
-def test_setup(GPIO, plasma):
-    force_reimport('fanshim')
-
-    from fanshim import FanShim
+def test_setup(GPIO, apa102, FanShim):
     fanshim = FanShim()
 
     GPIO.setwarnings.assert_called_once_with(False)
@@ -37,15 +12,10 @@ def test_setup(GPIO, plasma):
         mock.call(fanshim._pin_button, GPIO.IN, pull_up_down=GPIO.PUD_UP)
     ])
 
-    plasma.legacy.set_clear_on_exit.assert_called_once_with(True)
-    plasma.legacy.set_light_count.assert_called_once_with(1)
-    plasma.legacy.set_light.assert_called_once_with(0, 0, 0, 0)
+    apa102.APA102.assert_called_once_with(1, 15, 14, None, brightness=0.05)
 
 
-def test_button_disable(GPIO, plasma):
-    force_reimport('fanshim')
-
-    from fanshim import FanShim
+def test_button_disable(GPIO, apa102, FanShim):
     fanshim = FanShim(disable_button=True)
 
     GPIO.setwarnings.assert_called_once_with(False)
@@ -53,10 +23,7 @@ def test_button_disable(GPIO, plasma):
     GPIO.setup.assert_called_once_with(fanshim._pin_fancontrol, GPIO.OUT)
 
 
-def test_led_disable(GPIO, plasma):
-    force_reimport('fanshim')
-
-    from fanshim import FanShim
+def test_led_disable(GPIO, apa102, FanShim):
     fanshim = FanShim(disable_led=True)
 
     GPIO.setwarnings.assert_called_once_with(False)
@@ -66,10 +33,6 @@ def test_led_disable(GPIO, plasma):
         mock.call(fanshim._pin_button, GPIO.IN, pull_up_down=GPIO.PUD_UP)
     ])
 
-    plasma.legacy.set_clear_on_exit.assert_not_called()
-    plasma.legacy.set_light_count.assert_not_called()
-    plasma.legacy.set_light.assert_not_called()
+    assert not apa102.APA102.called
 
     fanshim.set_light(0, 0, 0)
-    plasma.legacy.set_light.assert_not_called()
-    plasma.legacy.show.assert_not_called()

--- a/library/tox.ini
+++ b/library/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35},qa
+envlist = py{27,35,37},qa
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This changeset adds disable_button and disable_led arguments to FanShim so that the GPIO setup for these features can be avoided.

This is mostly for issues with HyperPixel raised in #70 but any should be useful for other instances where Fan SHIM might conflict pins with another board.

This will break - https://github.com/pimoroni/fanshim-python/issues/49
Specifically - https://github.com/pimoroni/fanshim-python/commit/058ebc3f021736e2efcec60b1e6d10842cd2b857

But this is intentional, since `noled` is intended to avoid the LED being set up or written, for compatibility with add-on boards that require the pins. Additionally, writing the LED state *once* will not guarantee it actually stays that way, since the "smart" LEDs can often interpret random noise as signal and decide to turn themselves another colour.
