### PR TITLE
Fix issue with manual switch mode

### DIFF
--- a/examples/automatic.py
+++ b/examples/automatic.py
@@ -146,8 +146,8 @@ try:
             elif t <= args.off_threshold:
                 enable = False
 
-        if set_fan(enable):
-            last_change = t
+            if set_fan(enable):
+                last_change = t
 
         if not args.noled:
             update_led_temperature(t)


### PR DESCRIPTION
This fixes issue #79 seen when going to manual mode and switch ignored - caused by an incorrect Python indentation level. Tested and working find on 0.0.4 base.